### PR TITLE
feat(search):

### DIFF
--- a/stircraft/staticfiles/js/cocktail-search.js
+++ b/stircraft/staticfiles/js/cocktail-search.js
@@ -1,0 +1,539 @@
+/**
+ * StirCraft Cocktail Search & Filter JavaScript
+ * 
+ * Enhanced search functionality for the cocktail index page
+ * 
+ * Features:
+ * - Real-time search with debouncing
+ * - Tag-based filtering
+ * - Color filtering
+ * - Alcoholic/Non-alcoholic filtering
+ * - Sort options
+ * - URL state management
+ * - Quick filter buttons
+ * - Search history
+ * 
+ * Dependencies:
+ * - None (vanilla JavaScript)
+ */
+
+class CocktailSearch {
+    constructor() {
+        this.searchForm = document.querySelector('form[method="get"]');
+        this.queryInput = document.querySelector('input[name="query"]');
+        this.ingredientSelect = document.querySelector('select[name="ingredient"]');
+        this.spiritSelect = document.querySelector('select[name="spirit"]');
+        this.vesselSelect = document.querySelector('select[name="vessel"]');
+        this.alcoholicSelect = document.querySelector('select[name="is_alcoholic"]');
+        this.colorInput = document.querySelector('input[name="color"]');
+        this.sortSelect = document.querySelector('select[name="sort_by"]');
+        
+        this.debounceTimeout = null;
+        this.debounceDelay = 500; // ms
+        
+        this.init();
+    }
+    
+    init() {
+        if (!this.searchForm) return;
+        
+        this.bindEvents();
+        this.createQuickFilters();
+        this.createTagFilters();
+        this.createColorFilters();
+        this.restoreSearchState();
+        this.addSearchSuggestions();
+    }
+    
+    bindEvents() {
+        // Text search with debouncing
+        if (this.queryInput) {
+            this.queryInput.addEventListener('input', () => {
+                this.debounceSearch();
+            });
+        }
+        
+        // Color input with debouncing
+        if (this.colorInput) {
+            this.colorInput.addEventListener('input', () => {
+                this.debounceSearch();
+            });
+        }
+        
+        // Immediate submit for dropdowns
+        [this.ingredientSelect, this.spiritSelect, this.vesselSelect, this.alcoholicSelect, this.sortSelect].forEach(select => {
+            if (select) {
+                select.addEventListener('change', () => {
+                    this.submitSearch();
+                });
+            }
+        });
+        
+        // Form submission handler
+        this.searchForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.submitSearch();
+        });
+        
+        // Clear button
+        const clearButton = document.querySelector('a[href*="cocktail_index"]');
+        if (clearButton) {
+            clearButton.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.clearAllFilters();
+            });
+        }
+    }
+    
+    debounceSearch() {
+        clearTimeout(this.debounceTimeout);
+        this.debounceTimeout = setTimeout(() => {
+            this.submitSearch();
+        }, this.debounceDelay);
+    }
+    
+    submitSearch() {
+        this.saveSearchState();
+        this.searchForm.submit();
+    }
+    
+    createQuickFilters() {
+        const quickFilters = [
+            { 
+                label: '🍸 All Cocktails', 
+                params: {},
+                tooltip: 'Show all cocktails'
+            },
+            { 
+                label: '🥃 Alcoholic', 
+                params: { is_alcoholic: 'True' },
+                tooltip: 'Show only alcoholic drinks'
+            },
+            { 
+                label: '🚫 Non-Alcoholic', 
+                params: { is_alcoholic: 'False' },
+                tooltip: 'Show only mocktails and non-alcoholic drinks'
+            },
+            { 
+                label: '🆕 Newest', 
+                params: { sort_by: '-created_at' },
+                tooltip: 'Sort by newest first'
+            },
+            { 
+                label: '📝 A-Z', 
+                params: { sort_by: 'name' },
+                tooltip: 'Sort alphabetically'
+            }
+        ];
+        
+        const container = this.createQuickFiltersContainer();
+        if (container) {
+            quickFilters.forEach(filter => {
+                const button = this.createQuickFilterButton(filter);
+                container.appendChild(button);
+            });
+        }
+        
+        // Add spirit-specific filters
+        this.createSpiritFilters();
+    }
+    
+    createTagFilters() {
+        // Create common tag filters
+        const tagFilters = [
+            { label: '🌴 Tropical', query: 'tropical' },
+            { label: '🎉 Party', query: 'party' },
+            { label: '❄️ Frozen', query: 'frozen' },
+            { label: '🌙 Night', query: 'night' },
+            { label: '☀️ Summer', query: 'summer' },
+            { label: '🍎 Fall', query: 'fall autumn' },
+            { label: '❄️ Winter', query: 'winter cozy' },
+            { label: '🌸 Spring', query: 'spring fresh' },
+            { label: '💕 Romantic', query: 'romantic date' },
+            { label: '🏠 Cozy', query: 'cozy comfort' }
+        ];
+        
+        const container = this.createTagFiltersContainer();
+        if (container) {
+            tagFilters.forEach(filter => {
+                const button = this.createTagFilterButton(filter);
+                container.appendChild(button);
+            });
+        }
+    }
+    
+    createSpiritFilters() {
+        // Create spirit-based filter buttons
+        const spiritFilters = [
+            { label: '🥃 Rum Cocktails', spirit: 'rum' },
+            { label: '🍸 Gin Cocktails', spirit: 'gin' },
+            { label: '🥄 Vodka Cocktails', spirit: 'vodka' },
+            { label: '🥃 Whiskey Cocktails', spirit: 'whiskey bourbon rye scotch' },
+            { label: '🍷 Brandy Cocktails', spirit: 'brandy' }
+        ];
+        
+        const container = this.createSpiritFiltersContainer();
+        if (container) {
+            spiritFilters.forEach(filter => {
+                const button = this.createSpiritFilterButton(filter);
+                container.appendChild(button);
+            });
+        }
+    }
+    
+    createColorFilters() {
+        const colorFilters = [
+            { label: '🔴 Red', color: 'red', hex: '#dc3545' },
+            { label: '🟠 Orange', color: 'orange', hex: '#fd7e14' },
+            { label: '🟡 Yellow', color: 'yellow', hex: '#ffc107' },
+            { label: '🟢 Green', color: 'green', hex: '#198754' },
+            { label: '🔵 Blue', color: 'blue', hex: '#0d6efd' },
+            { label: '🟣 Purple', color: 'purple', hex: '#6f42c1' },
+            { label: '🟤 Brown', color: 'brown', hex: '#8B4513' },
+            { label: '⚪ Clear', color: 'clear', hex: '#f8f9fa' },
+            { label: '⚫ Dark', color: 'dark black', hex: '#212529' }
+        ];
+        
+        const container = this.createColorFiltersContainer();
+        if (container) {
+            colorFilters.forEach(filter => {
+                const button = this.createColorFilterButton(filter);
+                container.appendChild(button);
+            });
+        }
+    }
+    
+    createQuickFiltersContainer() {
+        const existingContainer = document.getElementById('quick-filters');
+        if (existingContainer) return existingContainer;
+        
+        const container = document.createElement('div');
+        container.id = 'quick-filters';
+        container.className = 'mb-3';
+        container.innerHTML = '<div class="row"><div class="col-12"><small class="text-muted me-2"><strong>Quick Filters:</strong></small></div></div><div class="row"><div class="col-12" id="quick-filters-buttons"></div></div>';
+        
+        // Insert before the search form
+        this.searchForm.parentNode.insertBefore(container, this.searchForm);
+        return container.querySelector('#quick-filters-buttons');
+    }
+    
+    createTagFiltersContainer() {
+        const existingContainer = document.getElementById('tag-filters');
+        if (existingContainer) return existingContainer;
+        
+        const container = document.createElement('div');
+        container.id = 'tag-filters';
+        container.className = 'mb-3';
+        container.innerHTML = '<div class="row"><div class="col-12"><small class="text-muted me-2"><strong>Filter by Vibe:</strong></small></div></div><div class="row"><div class="col-12" id="tag-filters-buttons"></div></div>';
+        
+        // Insert after quick filters
+        const quickFilters = document.getElementById('quick-filters');
+        if (quickFilters) {
+            quickFilters.parentNode.insertBefore(container, quickFilters.nextSibling);
+        } else {
+            this.searchForm.parentNode.insertBefore(container, this.searchForm);
+        }
+        return container.querySelector('#tag-filters-buttons');
+    }
+    
+    createColorFiltersContainer() {
+        const existingContainer = document.getElementById('color-filters');
+        if (existingContainer) return existingContainer;
+        
+        const container = document.createElement('div');
+        container.id = 'color-filters';
+        container.className = 'mb-3';
+        container.innerHTML = '<div class="row"><div class="col-12"><small class="text-muted me-2"><strong>Filter by Color:</strong></small></div></div><div class="row"><div class="col-12" id="color-filters-buttons"></div></div>';
+        
+        // Insert after tag filters
+        const tagFilters = document.getElementById('tag-filters');
+        if (tagFilters) {
+            tagFilters.parentNode.insertBefore(container, tagFilters.nextSibling);
+        } else {
+            this.searchForm.parentNode.insertBefore(container, this.searchForm);
+        }
+        return container.querySelector('#color-filters-buttons');
+    }
+    
+    createSpiritFiltersContainer() {
+        const existingContainer = document.getElementById('spirit-filters');
+        if (existingContainer) return existingContainer;
+        
+        const container = document.createElement('div');
+        container.id = 'spirit-filters';
+        container.className = 'mb-3';
+        container.innerHTML = '<div class="row"><div class="col-12"><small class="text-muted me-2"><strong>Filter by Spirit:</strong></small></div></div><div class="row"><div class="col-12" id="spirit-filters-buttons"></div></div>';
+        
+        // Insert after color filters
+        const colorFilters = document.getElementById('color-filters');
+        if (colorFilters) {
+            colorFilters.parentNode.insertBefore(container, colorFilters.nextSibling);
+        } else {
+            this.searchForm.parentNode.insertBefore(container, this.searchForm);
+        }
+        return container.querySelector('#spirit-filters-buttons');
+    }
+    
+    createQuickFilterButton(filter) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-outline-primary me-2 mb-2';
+        button.textContent = filter.label;
+        
+        if (filter.tooltip) {
+            button.title = filter.tooltip;
+        }
+        
+        button.addEventListener('click', () => {
+            this.applyFilter(filter.params);
+        });
+        
+        return button;
+    }
+    
+    createTagFilterButton(filter) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-outline-secondary me-2 mb-2';
+        button.textContent = filter.label;
+        button.title = `Search for ${filter.query} cocktails`;
+        
+        button.addEventListener('click', () => {
+            if (this.queryInput) {
+                this.queryInput.value = filter.query;
+                this.submitSearch();
+            }
+        });
+        
+        return button;
+    }
+    
+    createColorFilterButton(filter) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-outline-dark me-2 mb-2';
+        button.textContent = filter.label;
+        button.title = `Filter by ${filter.color} cocktails`;
+        button.style.borderColor = filter.hex;
+        
+        // Add color indicator
+        if (filter.color !== 'clear') {
+            button.style.background = `linear-gradient(45deg, ${filter.hex}22, transparent)`;
+        }
+        
+        button.addEventListener('click', () => {
+            if (this.colorInput) {
+                this.colorInput.value = filter.color;
+                this.submitSearch();
+            }
+        });
+        
+        return button;
+    }
+    
+    createSpiritFilterButton(filter) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-outline-warning me-2 mb-2';
+        button.textContent = filter.label;
+        button.title = `Find cocktails made with ${filter.spirit}`;
+        
+        button.addEventListener('click', () => {
+            if (this.queryInput) {
+                this.queryInput.value = filter.spirit;
+                this.submitSearch();
+            }
+        });
+        
+        return button;
+    }
+    
+    applyFilter(params) {
+        // Clear form first
+        this.clearForm();
+        
+        // Apply filter parameters
+        for (let [key, value] of Object.entries(params)) {
+            const field = this.searchForm.querySelector(`[name="${key}"]`);
+            if (field) {
+                field.value = value;
+            }
+        }
+        
+        this.submitSearch();
+    }
+    
+    clearForm() {
+        const inputs = this.searchForm.querySelectorAll('input, select');
+        inputs.forEach(input => {
+            if (input.type === 'checkbox' || input.type === 'radio') {
+                input.checked = false;
+            } else {
+                input.value = '';
+            }
+        });
+    }
+    
+    clearAllFilters() {
+        this.clearForm();
+        this.clearSearchState();
+        // Redirect to clean URL
+        window.location.href = this.searchForm.action || window.location.pathname;
+    }
+    
+    saveSearchState() {
+        if (!window.localStorage) return;
+        
+        const formData = new FormData(this.searchForm);
+        const searchState = {};
+        
+        for (let [key, value] of formData.entries()) {
+            if (value && value.trim() !== '') {
+                searchState[key] = value;
+            }
+        }
+        
+        try {
+            localStorage.setItem('stircraft_cocktail_search_state', JSON.stringify(searchState));
+        } catch (e) {
+            console.warn('Failed to save search state:', e);
+        }
+    }
+    
+    restoreSearchState() {
+        if (!window.localStorage) return;
+        
+        try {
+            const savedState = localStorage.getItem('stircraft_cocktail_search_state');
+            if (!savedState) return;
+            
+            const searchState = JSON.parse(savedState);
+            
+            // Only restore if URL doesn't have parameters (fresh page load)
+            if (window.location.search) return;
+            
+            for (let [key, value] of Object.entries(searchState)) {
+                const field = this.searchForm.querySelector(`[name="${key}"]`);
+                if (field && value) {
+                    field.value = value;
+                }
+            }
+        } catch (e) {
+            console.warn('Failed to restore search state:', e);
+        }
+    }
+    
+    clearSearchState() {
+        if (window.localStorage) {
+            try {
+                localStorage.removeItem('stircraft_cocktail_search_state');
+            } catch (e) {
+                console.warn('Failed to clear search state:', e);
+            }
+        }
+    }
+    
+    addSearchSuggestions() {
+        if (!this.queryInput) return;
+        
+        // Common search terms for suggestions
+        const suggestions = [
+            'margarita', 'mojito', 'martini', 'old fashioned', 'manhattan',
+            'whiskey', 'gin', 'vodka', 'rum', 'tequila', 'bourbon', 'rye', 'scotch',
+            'tropical', 'frozen', 'summer', 'winter', 'party',
+            'red', 'blue', 'green', 'clear', 'dark'
+        ];
+        
+        // Create datalist for autocomplete
+        const datalist = document.createElement('datalist');
+        datalist.id = 'cocktail-search-suggestions';
+        
+        suggestions.forEach(suggestion => {
+            const option = document.createElement('option');
+            option.value = suggestion;
+            datalist.appendChild(option);
+        });
+        
+        document.body.appendChild(datalist);
+        this.queryInput.setAttribute('list', 'cocktail-search-suggestions');
+    }
+    
+    // Public API methods
+    search(query) {
+        if (this.queryInput) {
+            this.queryInput.value = query;
+            this.submitSearch();
+        }
+    }
+    
+    filterByColor(color) {
+        if (this.colorInput) {
+            this.colorInput.value = color;
+            this.submitSearch();
+        }
+    }
+    
+    filterByAlcoholic(isAlcoholic) {
+        if (this.alcoholicSelect) {
+            this.alcoholicSelect.value = isAlcoholic ? 'True' : 'False';
+            this.submitSearch();
+        }
+    }
+    
+    setSort(sortBy) {
+        if (this.sortSelect) {
+            this.sortSelect.value = sortBy;
+            this.submitSearch();
+        }
+    }
+}
+
+// Initialize when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    // Only initialize if we have a search form on the cocktails page
+    if (document.querySelector('form[method="get"]') && window.location.pathname.includes('cocktail')) {
+        window.cocktailSearch = new CocktailSearch();
+        
+        // Add global convenience functions
+        window.searchCocktails = function(query) {
+            if (window.cocktailSearch) {
+                window.cocktailSearch.search(query);
+            }
+        };
+        
+        window.filterCocktailsByColor = function(color) {
+            if (window.cocktailSearch) {
+                window.cocktailSearch.filterByColor(color);
+            }
+        };
+        
+        window.filterCocktailsByAlcoholic = function(isAlcoholic) {
+            if (window.cocktailSearch) {
+                window.cocktailSearch.filterByAlcoholic(isAlcoholic);
+            }
+        };
+    }
+});
+
+// Enhanced keyboard shortcuts
+document.addEventListener('keydown', function(e) {
+    // Ctrl/Cmd + K to focus search
+    if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        const searchInput = document.querySelector('input[name="query"]');
+        if (searchInput) {
+            searchInput.focus();
+            searchInput.select();
+        }
+    }
+    
+    // Escape to clear search
+    if (e.key === 'Escape') {
+        const searchInput = document.querySelector('input[name="query"]');
+        if (searchInput && document.activeElement === searchInput) {
+            if (window.cocktailSearch) {
+                window.cocktailSearch.clearAllFilters();
+            }
+        }
+    }
+});

--- a/stircraft/stir_craft/forms/cocktail_forms.py
+++ b/stircraft/stir_craft/forms/cocktail_forms.py
@@ -395,6 +395,17 @@ class CocktailSearchForm(forms.Form):
         widget=forms.Select(attrs={'class': 'form-select'})
     )
     
+    spirit = forms.ModelChoiceField(
+        queryset=Ingredient.objects.filter(ingredient_type='spirit').order_by('name'),
+        required=False,
+        empty_label="Any spirit",
+        widget=forms.Select(attrs={
+            'class': 'form-select',
+            'title': 'Filter by base spirit (rum, vodka, gin, etc.)'
+        }),
+        help_text="Find cocktails that use a specific spirit as a base"
+    )
+    
     vessel = forms.ModelChoiceField(
         queryset=Vessel.objects.all().order_by('name'),
         required=False,

--- a/stircraft/stir_craft/templates/cocktails/index.html
+++ b/stircraft/stir_craft/templates/cocktails/index.html
@@ -25,6 +25,10 @@
 -->
 
     {% include 'partials/shared/_cocktail_index_header.html' %}
+    
+    <!-- Search and Filter Form -->
+    {% include 'partials/shared/_search_filter_form.html' %}
+    
     <div class="row">
         <!-- List of cocktails rendered via _cocktail_card partial -->
         <div class="col-12">
@@ -43,4 +47,8 @@
     {% include 'partials/shared/_pagination.html' with page_obj=page_obj %}
 </div>
 
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/cocktail-search.js' %}"></script>
 {% endblock %}

--- a/stircraft/stir_craft/templates/partials/shared/_search_filter_form.html
+++ b/stircraft/stir_craft/templates/partials/shared/_search_filter_form.html
@@ -2,7 +2,7 @@
 <div class="card mb-4">
     <div class="card-body">
         <form method="get" class="row g-3">
-            <div class="col-md-4">
+            <div class="col-md-3">
                 {{ search_form.query.label_tag }}
                 {{ search_form.query }}
             </div>
@@ -11,6 +11,10 @@
                 {{ search_form.ingredient }}
             </div>
             <div class="col-md-2">
+                {{ search_form.spirit.label_tag }}
+                {{ search_form.spirit }}
+            </div>
+            <div class="col-md-1">
                 {{ search_form.vessel.label_tag }}
                 {{ search_form.vessel }}
             </div>
@@ -18,7 +22,11 @@
                 {{ search_form.is_alcoholic.label_tag }}
                 {{ search_form.is_alcoholic }}
             </div>
-            <div class="col-md-2">
+            <div class="col-md-1">
+                {{ search_form.color.label_tag }}
+                {{ search_form.color }}
+            </div>
+            <div class="col-md-1">
                 {{ search_form.sort_by.label_tag }}
                 {{ search_form.sort_by }}
             </div>

--- a/stircraft/stir_craft/tests/test_cocktail_views.py
+++ b/stircraft/stir_craft/tests/test_cocktail_views.py
@@ -191,6 +191,31 @@ class CocktailViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Vodka Cocktail')
 
+    def test_cocktail_index_filter_by_spirit(self):
+        """Test filtering cocktails by spirit."""
+        # Create a spirit ingredient
+        rum = Ingredient.objects.create(
+            name='Dark Rum',
+            ingredient_type='spirit',
+            alcohol_content=40.0
+        )
+        
+        cocktail = Cocktail.objects.create(
+            name='Rum Cocktail',
+            instructions='Mix with rum',
+            creator=self.user
+        )
+        RecipeComponent.objects.create(
+            cocktail=cocktail,
+            ingredient=rum,
+            amount=50.0,
+            unit='ml'
+        )
+        
+        response = self.client.get(reverse('cocktail_index'), {'spirit': rum.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Rum Cocktail')
+
     def test_cocktail_update_happy_path(self):
         """Creator can update cocktail and components."""
         self.client.login(username='cocktail_user', password='test_password_123')

--- a/stircraft/stir_craft/tests/test_forms.py
+++ b/stircraft/stir_craft/tests/test_forms.py
@@ -311,3 +311,29 @@ class CocktailSearchFormTest(TestCase):
             form_data = {'sort_by': sort_option}
             form = CocktailSearchForm(data=form_data)
             self.assertTrue(form.is_valid(), f"Sort option '{sort_option}' should be valid")
+
+    def test_search_form_spirit_filter(self):
+        """Test spirit filter functionality."""
+        # Create a spirit ingredient
+        spirit = Ingredient.objects.create(
+            name='Test Rum',
+            ingredient_type='spirit',
+            alcohol_content=40.0
+        )
+        
+        form_data = {
+            'spirit': spirit.id
+        }
+        form = CocktailSearchForm(data=form_data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['spirit'], spirit)
+
+    def test_search_form_spirit_and_ingredient_combined(self):
+        """Test using both spirit and general ingredient filters."""
+        form_data = {
+            'spirit': self.ingredient.id,  # This should work even if ingredient isn't a spirit
+            'ingredient': self.ingredient.id,
+            'query': 'test cocktail'
+        }
+        form = CocktailSearchForm(data=form_data)
+        self.assertTrue(form.is_valid())

--- a/stircraft/stir_craft/tests/test_integration.py
+++ b/stircraft/stir_craft/tests/test_integration.py
@@ -246,7 +246,7 @@ class CocktailPerformanceTest(TestCase):
             cocktails.append(cocktail)
         
         # Test query count for index view
-        with self.assertNumQueries(5):  # Should be efficient with select_related/prefetch_related
+        with self.assertNumQueries(8):  # Updated to account for search form loading ingredients, spirits, and vessels
             response = self.client.get(reverse('cocktail_index'))
             self.assertEqual(response.status_code, 200)
 

--- a/stircraft/stir_craft/views.py
+++ b/stircraft/stir_craft/views.py
@@ -408,6 +408,10 @@ def cocktail_index(request):
         if cleaned_data.get('ingredient'):
             cocktails = cocktails.filter(components__ingredient=cleaned_data['ingredient'])
         
+        # Filter by spirit (specific to spirit ingredients)
+        if cleaned_data.get('spirit'):
+            cocktails = cocktails.filter(components__ingredient=cleaned_data['spirit'])
+        
         # Filter by vessel
         if cleaned_data.get('vessel'):
             cocktails = cocktails.filter(vessel=cleaned_data['vessel'])


### PR DESCRIPTION
 add spirit filter (form, view, template), JS quick filters, and tests; update perf test
This pull request adds a new "spirit" filter to the cocktail search functionality, allowing users to find cocktails by their base spirit (such as rum, vodka, gin, etc.). The changes span the form, templates, view logic, and tests to fully support and validate this feature.

### Feature: Spirit Filter for Cocktail Search

* Added a `spirit` field to the `CocktailSearchForm`, allowing users to filter cocktails by a specific spirit ingredient.
* Updated the cocktail index template and the shared search/filter form partial to include the new spirit filter field in the UI. Adjusted form layout to accommodate the new field. [[1]](diffhunk://#diff-529a4a480637a39baac7083613753ccab7af21e0bd8809e020fc2ed37d5773b6R28-R31) [[2]](diffhunk://#diff-291afd56905e91a27f5499127a29975738c19614201ee6d589c9c63f0fe7588dR14-R29) [[3]](diffhunk://#diff-291afd56905e91a27f5499127a29975738c19614201ee6d589c9c63f0fe7588dL5-R5)
* Modified the `cocktail_index` view to filter cocktails based on the selected spirit ingredient.

### Testing and Validation

* Added unit tests for filtering by spirit in both the view and form, including combined filtering with general ingredients. [[1]](diffhunk://#diff-776eb9d95ab132002e8a4e77faa3d089c37d127074858d31f558f85d9dca225aR194-R218) [[2]](diffhunk://#diff-f9eb48ed1a2432e85bf1ad438a7fd51b86ae4b761912d195ebd97eae3f0fe1c9R314-R339)
* Updated integration test to reflect the increased number of database queries due to the additional spirit filter.

### UI Enhancements

* Included the search form partial in the cocktail index page and added a JavaScript file block for potential search enhancements.